### PR TITLE
Fixup untar readable boundry

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctor/tar-stream",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "exports": {
     ".": "./mod.ts",
     "./tar": "./tar.ts",

--- a/tests.ts
+++ b/tests.ts
@@ -214,6 +214,11 @@ Deno.test('expandTarArchiveCheckingBodiesDefaultStream', async function () {
       size: text.length,
       iterable: [text.slice()],
     },
+    {
+      pathname: './text2.txt',
+      size: text.length,
+      iterable: [text.slice()],
+    },
   ])
     .pipeThrough(new TarStream())
     .pipeThrough(new UnTarStream())

--- a/untar.ts
+++ b/untar.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * The original tar	archive	header format.
+ * The original tar  archive  header format.
  */
 export interface OldStyleFormat {
   name: string
@@ -188,7 +188,7 @@ export class UnTarStream {
             readable: new ReadableStream({
               type: 'bytes',
               async pull(controller) {
-                if (i >= 0) {
+                if (i > 0) {
                   lock = true
                   const { done, value } = await async function () {
                     const x = await reader.read()
@@ -200,15 +200,12 @@ export class UnTarStream {
                   if (done) {
                     header = undefined
                     lock = false
-                    controller.close()
-                    controller.byobRequest?.respond(0)
-                    return
+                    throw new Error('Tarball ended unexpectedly.')
                   }
                   if (controller.byobRequest?.view) {
                     const buffer = new Uint8Array(
                       controller.byobRequest.view.buffer,
                     )
-
                     const size = buffer.length
                     if (size < value.length) {
                       buffer.set(value.slice(0, size))
@@ -228,6 +225,7 @@ export class UnTarStream {
                     reader.cancel(reason)
                   }
                   controller.close()
+                  controller.byobRequest?.respond(0)
                 }
               },
               async cancel(r) {

--- a/untar.ts
+++ b/untar.ts
@@ -3,7 +3,7 @@
  */
 
 /**
- * The original tar  archive  header format.
+ * The original tar archive header format.
  */
 export interface OldStyleFormat {
   name: string

--- a/untar.ts
+++ b/untar.ts
@@ -200,7 +200,8 @@ export class UnTarStream {
                   if (done) {
                     header = undefined
                     lock = false
-                    throw new Error('Tarball ended unexpectedly.')
+                    controller.error('Tarball ended unexpectedly.')
+                    return
                   }
                   if (controller.byobRequest?.view) {
                     const buffer = new Uint8Array(


### PR DESCRIPTION
# Motivation

Since each `TarEntry` from UnTarStream has its own `readable`, the boundry of the readable is incorrect, that will cause the readable reads next entry's header in the whole tar stream.

This patch fixup this situation.

# Observation

By running the test `expandTarArchiveCheckingBodiesDefaultStream` with addition file entry will get error:

Test code:

https://github.com/david50407/tar-stream/blob/fix/untar-readable-boundry/tests.ts#L205-L242

Output:

```
 ERRORS

expandTarArchiveCheckingBodiesDefaultStream => ./tests.ts:205:6
error: RangeError: offset is out of bounds
        buffer.set(value, offset)
               ^
    at Uint8Array.set (<anonymous>)
    at file:///.../tar-stream/tests.ts:236:16
```

This is caused by the boundry of `readable.pull` in `TarEntry` is incorrect while `readable.cancel` sets correct boundry.

# Solution

Fixup the boundry and detect "Tarball ended unexpectedly" while reading the `TarEntry.readable` stream.

This patch also includes the test above.
