### PR TITLE
Avoid infinite loop when spliting pathname

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,8 +5,10 @@
     "devminor",
     "gname",
     "linkname",
+    "loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
     "typeflag",
     "untar",
-    "ustar"
+    "ustar",
+    "Veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery"
   ]
 }

--- a/tar.ts
+++ b/tar.ts
@@ -255,26 +255,28 @@ export function parsePathname(
     throw new Error('Invalid Pathname! Pathname cannot exceed 256 bytes.')
   }
 
-  let i = Math.max(0, name.lastIndexOf(SLASH_CODE_POINT))
-  if (pathname.slice(i + 1).length > 100) {
+  // If length of last part is > 100, then there's no possible answer to split the path
+  let suitableSlashPos = Math.max(0, name.lastIndexOf(SLASH_CODE_POINT)) // always holds position of '/'
+  if (name.length - suitableSlashPos > 100) {
     throw new Error('Invalid Filename! Filename cannot exceed 100 bytes.')
   }
 
-  for (; i > 0; --i) {
-    i = name.lastIndexOf(SLASH_CODE_POINT, i) + 1
-    if (name.slice(i + 1).length > 100) {
-      i = Math.max(0, name.indexOf(SLASH_CODE_POINT, i + 1))
+  for (let nextPos = suitableSlashPos; nextPos > 0; suitableSlashPos = nextPos) {
+    // disclaimer: '/' won't appear at pos 0, so nextPos always be > 0 or = -1
+    nextPos = name.lastIndexOf(SLASH_CODE_POINT, suitableSlashPos - 1)
+    // disclaimer: since name.length > 100 in this case, if nextPos = -1, name.length - nextPos will also > 100
+    if (name.length - nextPos > 100) {
       break
     }
   }
 
-  const prefix = name.slice(0, i)
+  const prefix = name.slice(0, suitableSlashPos)
   if (prefix.length > 155) {
     throw new Error(
       'Invalid Pathname! Pathname needs to be split-able on a forward slash separator into [155, 100] bytes respectively.',
     )
   }
-  return [prefix, name.slice(i + 1)]
+  return [prefix, name.slice(suitableSlashPos + 1)]
 }
 
 /**

--- a/tar.ts
+++ b/tar.ts
@@ -88,7 +88,10 @@ export class TarStream {
         const pathname = typeof chunk.pathname === 'string'
           ? parsePathname(chunk.pathname, !('size' in chunk))
           : function () {
-            if ('size' in chunk === (chunk.pathname[1].slice(-1)[0] === SLASH_CODE_POINT)) {
+            if (
+              'size' in chunk ===
+                (chunk.pathname[1].slice(-1)[0] === SLASH_CODE_POINT)
+            ) {
               controller.error(
                 `Pre-parsed pathname for ${
                   'size' in chunk ? 'directory' : 'file'
@@ -261,7 +264,11 @@ export function parsePathname(
     throw new Error('Invalid Filename! Filename cannot exceed 100 bytes.')
   }
 
-  for (let nextPos = suitableSlashPos; nextPos > 0; suitableSlashPos = nextPos) {
+  for (
+    let nextPos = suitableSlashPos;
+    nextPos > 0;
+    suitableSlashPos = nextPos
+  ) {
     // disclaimer: '/' won't appear at pos 0, so nextPos always be > 0 or = -1
     nextPos = name.lastIndexOf(SLASH_CODE_POINT, suitableSlashPos - 1)
     // disclaimer: since name.length > 100 in this case, if nextPos = -1, name.length - nextPos will also > 100

--- a/tar.ts
+++ b/tar.ts
@@ -49,6 +49,8 @@ export interface TarDir {
  */
 export type TarInput = TarFile | TarDir
 
+const SLASH_CODE_POINT = '/'.charCodeAt(0)
+
 /**
  * A TransformStream that creates a Tarball. Taking in a
  * ReadableStream<TarInput> and outputting a ReadableStream<Uint8Array>.
@@ -86,7 +88,7 @@ export class TarStream {
         const pathname = typeof chunk.pathname === 'string'
           ? parsePathname(chunk.pathname, !('size' in chunk))
           : function () {
-            if ('size' in chunk === (chunk.pathname[1].slice(-1)[0] === 47)) {
+            if ('size' in chunk === (chunk.pathname[1].slice(-1)[0] === SLASH_CODE_POINT)) {
               controller.error(
                 `Pre-parsed pathname for ${
                   'size' in chunk ? 'directory' : 'file'
@@ -253,15 +255,15 @@ export function parsePathname(
     throw new Error('Invalid Pathname! Pathname cannot exceed 256 bytes.')
   }
 
-  let i = Math.max(0, name.lastIndexOf(47))
+  let i = Math.max(0, name.lastIndexOf(SLASH_CODE_POINT))
   if (pathname.slice(i + 1).length > 100) {
     throw new Error('Invalid Filename! Filename cannot exceed 100 bytes.')
   }
 
   for (; i > 0; --i) {
-    i = name.lastIndexOf(47, i) + 1
+    i = name.lastIndexOf(SLASH_CODE_POINT, i) + 1
     if (name.slice(i + 1).length > 100) {
-      i = Math.max(0, name.indexOf(47, i + 1))
+      i = Math.max(0, name.indexOf(SLASH_CODE_POINT, i + 1))
       break
     }
   }

--- a/tests.ts
+++ b/tests.ts
@@ -283,7 +283,6 @@ Deno.test('expandTarArchiveCheckingBodiesByteStream', async function () {
   }
 })
 
-
 Deno.test('parsePathname()', () => {
   const encoder = new TextEncoder()
 
@@ -325,6 +324,7 @@ Deno.test('parsePathname()', () => {
       ),
     ],
   )
+})
 
 Deno.test('UnTarStream() with size equals to multiple of 512', async () => {
   const size = 512 * 3

--- a/tests.ts
+++ b/tests.ts
@@ -277,3 +277,39 @@ Deno.test('expandTarArchiveCheckingBodiesByteStream', async function () {
     }
   }
 })
+
+Deno.test('TarStream() with extra long pathname', async () => {
+  const text = new TextEncoder().encode('Hello World!')
+
+  const readable = ReadableStream.from<TarInput>([
+    {
+      // 100 || N
+      pathname: './Veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery/LongPath',
+    },
+    {
+      // 16 (<155) || 95 (<100)
+      //                           v Split here
+      pathname: './some random path/with/loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong/path',
+    },
+    {
+      // test with regular file
+      pathname: './some random path/with/loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong/file',
+      size: text.length,
+      iterable: [text.slice()],
+    },
+  ])
+    .pipeThrough(new TarStream())
+    .pipeThrough(new UnTarStream())
+
+  const pathnames: string[] = []
+  for await (const item of readable) {
+    pathnames.push(item.pathname)
+    item.readable?.cancel()
+  }
+  assertEquals(pathnames, [
+    'Veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery/LongPath/',
+    'some random path/with/loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong/path/',
+    'some random path/with/loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong/file',
+  ])
+})
+


### PR DESCRIPTION
# Motivation

When tar-ing a long pathname, it should be splitted into two pieces, but current implementation gets into a infinite loop.

This patch fixes the problem.

# Observation

For a test below:

```ts
Deno.test('TarStream() with extra long pathname', async () => {
  const readable = ReadableStream.from<TarInput>([
    {
      // 100 || N
      pathname: './Veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery/LongPath',
    },
  ])
    .pipeThrough(new TarStream())
    .pipeThrough(new UnTarStream())

  const pathnames: string[] = []
  for await (const item of readable) {
    pathnames.push(item.pathname)
    item.readable?.cancel()
  }
  assertEquals(pathnames, [
    'Veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeery/LongPath/',
  ])
})
```

It will cause `parsePathname` get into a infinite loop for finding position of a suitable '/' to split.

https://github.com/BlackAsLight/tar-stream/blob/5f07d4e3a30f539e73ac8855822da4b77007e22a/tar.ts#L261-L267

By printing some variables before line 262, we will get:

```ts
{ "name.length": 110, i: 109, "name[i]": "/" }
```

Which means in the loop, we are always finding the previous '/' from the position of last '/', so `i` will never get updates.

# Solution

Simple solution is changing line 262 to this:

```diff
-    i = name.lastIndexOf(47, i) + 1 
+    i = name.lastIndexOf(47, i - 1)
```

But considering performance and readability of codes, this patch changes the variable name and the method of calcuation .

After applying the patch, the test above will pass correctly.

# Note

For readability of codes, this patch also introduced a const `SLASH_CODE_POINT` which presents the code point of charactor slash (`/`, 47).
