### PR TITLE
Correct untar padding removal when last part has size = 512

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@doctor/tar-stream",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "exports": {
     ".": "./mod.ts",
     "./tar": "./tar.ts",

--- a/tests.ts
+++ b/tests.ts
@@ -294,18 +294,12 @@ Deno.test('UnTarStream() with size equals to multiple of 512', async () => {
 
   for await (const item of readable) {
     if (item.readable) {
-      const buffer = new Uint8Array(data.length)
-      let offset = 0
-      const reader = item.readable.getReader()
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) {
-          break
-        }
-        buffer.set(value, offset)
-        offset += value.length
-      }
-      assertEquals(buffer, data)
+      assertEquals(
+        Uint8Array.from(
+          (await Array.fromAsync(item.readable)).map((x) => [...x]).flat()
+        ),
+        data
+      )
     }
   }
 })

--- a/untar.ts
+++ b/untar.ts
@@ -192,7 +192,7 @@ export class UnTarStream {
                   lock = true
                   const { done, value } = await async function () {
                     const x = await reader.read()
-                    if (!x.done && i-- === 1) {
+                    if (!x.done && i-- === 1 && size % 512 > 0) {
                       x.value = x.value.slice(0, size % 512) // Slice off suffix padding.
                     }
                     return x

--- a/untar.ts
+++ b/untar.ts
@@ -192,7 +192,7 @@ export class UnTarStream {
                   lock = true
                   const { done, value } = await async function () {
                     const x = await reader.read()
-                    if (!x.done && i-- === 1 && size % 512 > 0) {
+                    if (!x.done && i-- === 1 && size % 512) {
                       x.value = x.value.slice(0, size % 512) // Slice off suffix padding.
                     }
                     return x


### PR DESCRIPTION
# Motivation

During untar, the readable stream will strip padding from last piece of the entry. But it will strip whole data when desired size of the piece is 512.

# Obvervation

For the following test:

```ts
Deno.test('UnTarStream() with size equals to multiple of 512', async () => {
  const size = 512 * 3
  const data = Uint8Array.from({ length: size }, () => Math.floor(Math.random() * 256))

  const readable = ReadableStream.from<TarInput>([
    {
      pathname: 'name',
      size,
      iterable: [data.slice()],
    },
  ])
    .pipeThrough(new TarStream())
    .pipeThrough(new UnTarStream())

  for await (const item of readable) {
    if (item.readable) {
      const buffer = new Uint8Array(data.length)
      let offset = 0
      const reader = item.readable.getReader()
      while (true) {
        const { done, value } = await reader.read()
        if (done) {
          break
        }
        buffer.set(value, offset)
        offset += value.length
      }
      assertEquals(buffer, data)
    }
  }
})
```

current impl. of untar will occur an error:

```
UnTarStream() with size equals to multiple of 512 => ./tests.ts:316:6
error: TypeError: Failed to execute 'enqueue' on 'ReadableByteStreamController': Argument 1 length must be non-zero
                    controller.enqueue(value)
                               ^
    at Module.makeException (ext:deno_webidl/00_webidl.js:91:10)
    at ReadableByteStreamController.enqueue (ext:deno_web/06_streams.js:5880:20)
    at Object.pull (file:///.../tar-stream/untar.ts:220:32)
```

this is caused by codes below:

https://github.com/BlackAsLight/tar-stream/blob/5f07d4e3a30f539e73ac8855822da4b77007e22a/untar.ts#L193-L199

In line 196, when size can be divided by 512, result of `size % 512` will be `0`

# Solution

The simple solution is add a condition to line 195:

```diff
-                    if (!x.done && i-- === 1) {
+                    if (!x.done && i-- === 1 && size % 512 > 0) {
                       x.value = x.value.slice(0, size % 512) // Slice off suffix padding.
                     }
```

After applying this patch, the test above will pass.